### PR TITLE
Move setting of alternate HOME in dotnet bbclass

### DIFF
--- a/classes/dotnet.bbclass
+++ b/classes/dotnet.bbclass
@@ -5,10 +5,9 @@ DEPENDS_prepend += "dotnet-sdk-native "
 
 B = "${S}/out"
 
-# Don't use users's $HOME/.dotnet directory
-export HOME = "${WORKDIR}"
-
 dotnet_do_configure() {
+    # Don't use users's $HOME/.dotnet during configuration
+    export HOME = "${WORKDIR}"
     if [ -z ${DOTNET_PROJECT} ] ; then
      bberror "DOTNET_PROJECT must be specified!"
      exit -1
@@ -18,6 +17,8 @@ dotnet_do_configure() {
 }
 
 dotnet_do_compile()  {
+    # Don't use users's $HOME/.dotnet during compilation
+    export HOME = "${WORKDIR}"
     echo "Building project ${DOTNET_PROJECT}"
 
     if [ "${TARGET_ARCH}" = "x86_64" ]; then


### PR DESCRIPTION
Move setting of alternate HOME in dotnet bbclass to inside configure and compilation steps

Recipe wide HOME change made $HOME/.ssh and $HOME/.git unavailable to
fetcher