### PR TITLE
Update .NET SDK to version 6.0.402

### DIFF
--- a/classes/dotnet.bbclass
+++ b/classes/dotnet.bbclass
@@ -43,9 +43,8 @@ dotnet_do_install() {
     cp -rv * ${D}/opt/dotnet/${PN}
 }
 
-INSANE_SKIP_${PN}_append += "already-stripped"
-INSANE_SKIP_${PN}_append += "staticdev"
-INSANE_SKIP_${PN}_append += "file-rdeps"
+INSANE_SKIP:${PN}:append = " staticdev"
+INSANE_SKIP:${PN}:append = " file-rdeps"
 
 FILES_${PN} += "/opt/dotnet/${PN}"
 

--- a/recipes-runtime/dotnet/dotnet-sdk-native.bb
+++ b/recipes-runtime/dotnet/dotnet-sdk-native.bb
@@ -1,15 +1,15 @@
 
-DESCRIPTION = ".NET Core 5.0 SDK (v6.0.1) - Linux x64 Binaries"
+DESCRIPTION = ".NET Core 5.0 SDK (v6.0.4) - Linux x64 Binaries"
 HOMEPAGE = "https://dotnet.microsoft.com/en-us/download/dotnet/6.0"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=9fc642ff452b28d62ab19b7eea50dfb9"
 
-SOURCE_FILE = "dotnet-sdk-6.0.101-linux-x64.tar.gz"
+SOURCE_FILE = "dotnet-sdk-6.0.402-linux-x64.tar.gz"
 
-SRC_URI = "https://download.visualstudio.microsoft.com/download/pr/ede8a287-3d61-4988-a356-32ff9129079e/bdb47b6b510ed0c4f0b132f7f4ad9d5a/${SOURCE_FILE};unpack=0 \
+SRC_URI = "https://download.visualstudio.microsoft.com/download/pr/d3e46476-4494-41b7-a628-c517794c5a6a/6066215f6c0a18b070e8e6e8b715de0b/${SOURCE_FILE};unpack=0 \
            file://LICENSE.txt \
 "
-SRC_URI[sha256sum] = "95a1b5360b234e926f12327d68c4a0d7b7206134dca1b570a66dc7a8a4aed705"
+SRC_URI[sha512sum] = "972c2d9fff6a09ef8f2e6bbaa36ae5869f4f7f509ae5d28c4611532eb34be10c629af98cdf211d86dc4bc6edebb04a2672a97f78c3e0f2ff267017f8c9c59d4e"
 
 inherit native
 

--- a/recipes-test/dotnet-hello-world.bb/files/hello-world/hello-world.csproj
+++ b/recipes-test/dotnet-hello-world.bb/files/hello-world/hello-world.csproj
@@ -1,5 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>netcoreapp5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Other changes related to the update:
- Seems like new dotnet version is actually stripping the binary which made bitbake to give warning that binary is already stripped
- Added missing space in INSANE_SKIP append