### PR TITLE
classes/dotnet: add support for file path in DOTNET_PROJECT

### DIFF
--- a/classes/dotnet.bbclass
+++ b/classes/dotnet.bbclass
@@ -18,8 +18,14 @@ python () {
     bb.fatal("Architecture not supported: " + target_arch)
 }
 
+python () {
+    from pathlib import Path
+    dotnet_project = d.getVar("DOTNET_PROJECT")
+    d.appendVar('DOTNET_PROJECT_NAME', Path(dotnet_project).stem)
+}
+
 ARTIFACTS_DIR = "${WORKDIR}/artifacts"
-RELEASE_DIR ?= "${ARTIFACTS_DIR}/publish/${DOTNET_PROJECT}/release_${BUILD_TARGET}/"
+RELEASE_DIR ?= "${ARTIFACTS_DIR}/publish/${DOTNET_PROJECT_NAME}/release_${BUILD_TARGET}/"
 
 INSTALL_DIR ?= "/opt/dotnet/${PN}"
 


### PR DESCRIPTION
If DOTNET_PROJECT was a path to a project file (e.g. src/myproject/myproject.csproj), then the path of the project would be concatenated along with the filename and extension. This is also in line with dotnet's artifacts ouput layout: https://learn.microsoft.com/en-us/dotnet/core/sdk/artifacts-output